### PR TITLE
Declare "offset2" on a separate line

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/MapsActivity.java
@@ -511,7 +511,8 @@ public class MapsActivity extends BaseActivity implements ItemizedLayer.OnItemGe
 
         try {
             gl.glReadPixels(x, y, w, h, GL10.GL_RGBA, GL10.GL_UNSIGNED_BYTE, intBuffer);
-            int offset1, offset2;
+            int offset1;
+            int offset2;
             for (int i = 0; i < h; i++) {
                 offset1 = i * w;
                 offset2 = (h - i - 1) * w;


### PR DESCRIPTION
Issue: 
https://github.com/akshitdesai/OSMDashboard-Winter-2024-SOEN-6431/issues/12#issue-2135013122

Description:
This pull request addresses the issue of declaring variables offset1 and offset2 on the same line after the glReadPixels method call. The proposed change separates the declarations into individual lines, adhering to best practices for code readability and maintainability.

Changes Made:

Separated they declarations of offset1 and offset2 onto individual lines.